### PR TITLE
Bugfix: getActiveMicrophones can fail to retrieve information in Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.7]
+### Bug fix
+- Fixed bug in `getActiveMicrophones` when the information cannot be retrieved in Android.
+
 ## [0.0.6]
 ### Bug fix
-- fixed bugs and code structure
+- Fixed bugs and code structure
 
 ## [0.0.5]
 ### Added

--- a/android/src/main/kotlin/com/dhiman/mic_info/MicInfoPlugin.kt
+++ b/android/src/main/kotlin/com/dhiman/mic_info/MicInfoPlugin.kt
@@ -68,7 +68,7 @@ class MicInfoPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     val microphoneNames = mutableListOf<Map<String, String>>()
 
     for (config in recordingConfigurations) {
-      val device = config.getAudioDevice()
+      val device = config.getAudioDevice() ?: continue
       // Check if the device is a supported device microphone
       if (device.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO || device.type == AudioDeviceInfo.TYPE_BUILTIN_MIC || device.type == AudioDeviceInfo.TYPE_USB_HEADSET || device.type == AudioDeviceInfo.TYPE_WIRED_HEADSET ) {
         // Add the microphone information (product name and id) to the list

--- a/lib/mic_info_method_channel.dart
+++ b/lib/mic_info_method_channel.dart
@@ -10,7 +10,8 @@ class MethodChannelMicInfo extends MicInfoPlatform {
   @visibleForTesting
   final methodChannel = const MethodChannel('dhiman/mic_info');
 
-  /// Retrieves the Bluetooth microphone using a method channel call to the native platform.
+  /// Retrieves the active microphones using a method channel call to the native platform.
+  /// In Android, if the microphone cannot be retrieved, the method will return an empty list.
   @override
   Future<List<dynamic>> getActiveMicrophones() async {
     // Invoke the 'getCommunicationDevice' method on the method channel

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mic_info
 description: Mic Info Plugin is a Flutter plugin that retrieves information about connected microphones on Android and iOS. It supports detecting built-in, wired (including USB connector microphones), and Bluetooth microphones, making it ideal for applications requiring audio input management.
-version: 0.0.6
+version: 0.0.7
 homepage: https://github.com/devakar-dhiman/mic_info.git
 
 environment:


### PR DESCRIPTION
Fixes #3 
https://developer.android.com/reference/android/media/AudioRecordingConfiguration#getAudioDevice()

> Returns the audio recording device or `null` if this information cannot be retrieved

When `null` is returned, the plugin was throwing an exception.